### PR TITLE
Depreciate the use of sending UpdateSelectedSlotC2SPacket

### DIFF
--- a/src/main/java/net/shoreline/client/api/module/PlaceBlockModule.java
+++ b/src/main/java/net/shoreline/client/api/module/PlaceBlockModule.java
@@ -4,7 +4,6 @@ import net.minecraft.block.Block;
 import net.minecraft.block.Blocks;
 import net.minecraft.item.BlockItem;
 import net.minecraft.item.ItemStack;
-import net.minecraft.network.packet.c2s.play.UpdateSelectedSlotC2SPacket;
 import net.minecraft.util.math.BlockPos;
 import net.shoreline.client.impl.module.combat.SurroundModule;
 import net.shoreline.client.init.Managers;
@@ -53,12 +52,12 @@ public class PlaceBlockModule extends RotationModule {
         int prev = mc.player.getInventory().selectedSlot;
         if (prev != slot) {
             mc.player.getInventory().selectedSlot = slot;
-            Managers.NETWORK.sendPacket(new UpdateSelectedSlotC2SPacket(slot));
+            Managers.INVENTORY.setSlot(slot);
         }
         float[] rotations = Managers.INTERACT.placeBlock(pos, rotate, strictDirection);
         if (prev != slot) {
             mc.player.getInventory().selectedSlot = prev;
-            Managers.NETWORK.sendPacket(new UpdateSelectedSlotC2SPacket(prev));
+            Managers.INVENTORY.setSlot(prev);
         }
         return rotations;
     }

--- a/src/main/java/net/shoreline/client/impl/module/combat/AuraModule.java
+++ b/src/main/java/net/shoreline/client/impl/module/combat/AuraModule.java
@@ -204,8 +204,7 @@ public class AuraModule extends RotationModule {
         if (autoSwapConfig.getValue() && autoSwapTimer.passed(500) && !sword) {
             int slot = getSwordSlot();
             if (slot != -1) {
-                mc.player.getInventory().selectedSlot = slot;
-                Managers.NETWORK.sendPacket(new UpdateSelectedSlotC2SPacket(slot));
+                Managers.INVENTORY.setClientSlot(slot);
             }
         }
         if (!isHoldingSword() || !shouldWaitCrit()) {

--- a/src/main/java/net/shoreline/client/impl/module/combat/AutoCrystalModule.java
+++ b/src/main/java/net/shoreline/client/impl/module/combat/AutoCrystalModule.java
@@ -502,9 +502,7 @@ public class AutoCrystalModule extends RotationModule {
             mc.interactionManager.clickSlot(mc.player.playerScreenHandler.syncId,
                     slot + 36, mc.player.getInventory().selectedSlot, SlotActionType.SWAP, mc.player);
         } else {
-            mc.player.getInventory().selectedSlot = slot;
-            // ((AccessorClientPlayerInteractionManager) mc.interactionManager).hookSyncSelectedSlot();
-            Managers.NETWORK.sendPacket(new UpdateSelectedSlotC2SPacket(slot));
+            Managers.INVENTORY.setClientSlot(slot);
         }
     }
 

--- a/src/main/java/net/shoreline/client/impl/module/combat/AutoPotModule.java
+++ b/src/main/java/net/shoreline/client/impl/module/combat/AutoPotModule.java
@@ -6,7 +6,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.PotionItem;
 import net.minecraft.network.packet.c2s.play.PlayerInteractItemC2SPacket;
 import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket;
-import net.minecraft.network.packet.c2s.play.UpdateSelectedSlotC2SPacket;
 import net.minecraft.potion.PotionUtil;
 import net.minecraft.screen.slot.SlotActionType;
 import net.minecraft.util.Hand;
@@ -77,7 +76,7 @@ public class AutoPotModule extends RotationModule {
                             instantHealth, slotConfig.getValue(),
                             SlotActionType.SWAP, mc.player);
                     potionTimer.reset();
-                    Managers.NETWORK.sendPacket(new UpdateSelectedSlotC2SPacket(slotConfig.getValue()));
+                    Managers.INVENTORY.setClientSlot(slotConfig.getValue());
                     if (handFixConfig.getValue()) {
                         Managers.NETWORK.sendSequencedPacket(id ->
                                 new PlayerInteractItemC2SPacket(Hand.MAIN_HAND, id));
@@ -85,7 +84,7 @@ public class AutoPotModule extends RotationModule {
                         Managers.NETWORK.sendSequencedPacket(id ->
                                 new PlayerInteractItemC2SPacket(Hand.OFF_HAND, id));
                     }
-                    Managers.NETWORK.sendPacket(new UpdateSelectedSlotC2SPacket(mc.player.getInventory().selectedSlot));
+                    Managers.INVENTORY.syncToClient();
                     Managers.NETWORK.sendPacket(new PlayerMoveC2SPacket.PositionAndOnGround(mc.player.getX(),
                             mc.player.getY() + 0.42, mc.player.getZ(), true));
                     Managers.NETWORK.sendPacket(new PlayerMoveC2SPacket.PositionAndOnGround(mc.player.getX(),
@@ -124,7 +123,7 @@ public class AutoPotModule extends RotationModule {
                     instantHealth, slotConfig.getValue(),
                     SlotActionType.SWAP, mc.player);
             potionTimer.reset();
-            Managers.NETWORK.sendPacket(new UpdateSelectedSlotC2SPacket(slotConfig.getValue()));
+            Managers.INVENTORY.setSlot(slotConfig.getValue());
             if (handFixConfig.getValue()) {
                 Managers.NETWORK.sendSequencedPacket(id ->
                         new PlayerInteractItemC2SPacket(Hand.MAIN_HAND, id));
@@ -132,7 +131,7 @@ public class AutoPotModule extends RotationModule {
                 Managers.NETWORK.sendSequencedPacket(id ->
                         new PlayerInteractItemC2SPacket(Hand.OFF_HAND, id));
             }
-            Managers.NETWORK.sendPacket(new UpdateSelectedSlotC2SPacket(mc.player.getInventory().selectedSlot));
+            Managers.INVENTORY.syncToClient();
             potion = false;
         }
     }

--- a/src/main/java/net/shoreline/client/impl/module/combat/AutoTotemModule.java
+++ b/src/main/java/net/shoreline/client/impl/module/combat/AutoTotemModule.java
@@ -176,13 +176,11 @@ public class AutoTotemModule extends ToggleModule {
             } else if (offhand.isEmpty() || !offhand.getItem().equals(Items.TOTEM_OF_UNDYING)) {
                 if (hotbarTotemConfig.getValue()) {
                     int prev = mc.player.getInventory().selectedSlot;
-                    mc.player.getInventory().selectedSlot = slotTotem;
-                    Managers.NETWORK.sendPacket(new UpdateSelectedSlotC2SPacket(slotTotem));
+                    Managers.INVENTORY.setClientSlot(slotTotem);
                     Managers.NETWORK.sendPacket(new PlayerActionC2SPacket(
                             PlayerActionC2SPacket.Action.SWAP_ITEM_WITH_OFFHAND,
                             BlockPos.ORIGIN, Direction.DOWN));
-                    mc.player.getInventory().selectedSlot = prev;
-                    Managers.NETWORK.sendPacket(new UpdateSelectedSlotC2SPacket(prev));
+                    Managers.INVENTORY.setClientSlot(prev);
                 } else {
                     preClickSlot();
                     boolean returnClick = mc.player.currentScreenHandler.getCursorStack().isEmpty();

--- a/src/main/java/net/shoreline/client/impl/module/misc/AutoEatModule.java
+++ b/src/main/java/net/shoreline/client/impl/module/misc/AutoEatModule.java
@@ -4,7 +4,6 @@ import net.minecraft.client.option.KeyBinding;
 import net.minecraft.entity.player.HungerManager;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
-import net.minecraft.network.packet.c2s.play.UpdateSelectedSlotC2SPacket;
 import net.minecraft.util.Hand;
 import net.shoreline.client.api.config.Config;
 import net.shoreline.client.api.config.setting.NumberConfig;
@@ -47,8 +46,7 @@ public class AutoEatModule extends ToggleModule {
     public void onTick(TickEvent event) {
         if (!mc.player.isUsingItem()) {
             if (prevSlot != -1) {
-                mc.player.getInventory().selectedSlot = prevSlot;
-                Managers.NETWORK.sendPacket(new UpdateSelectedSlotC2SPacket(prevSlot));
+                Managers.INVENTORY.setClientSlot(prevSlot);
                 prevSlot = -1;
             }
             KeyBinding.setKeyPressed(((AccessorKeyBinding) mc.options.useKey).getBoundKey(), false);
@@ -65,8 +63,7 @@ public class AutoEatModule extends ToggleModule {
                 mc.player.setCurrentHand(Hand.OFF_HAND);
             } else {
                 prevSlot = mc.player.getInventory().selectedSlot;
-                mc.player.getInventory().selectedSlot = slot;
-                Managers.NETWORK.sendPacket(new UpdateSelectedSlotC2SPacket(slot));
+                Managers.INVENTORY.setClientSlot(slot);
             }
             KeyBinding.setKeyPressed(((AccessorKeyBinding) mc.options.useKey).getBoundKey(), true);
         }

--- a/src/main/java/net/shoreline/client/impl/module/misc/MiddleClickModule.java
+++ b/src/main/java/net/shoreline/client/impl/module/misc/MiddleClickModule.java
@@ -3,7 +3,6 @@ package net.shoreline.client.impl.module.misc;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
-import net.minecraft.network.packet.c2s.play.UpdateSelectedSlotC2SPacket;
 import net.minecraft.util.Hand;
 import net.shoreline.client.api.config.Config;
 import net.shoreline.client.api.config.setting.EnumConfig;
@@ -64,11 +63,9 @@ public class MiddleClickModule extends ToggleModule {
                 }
                 if (slot != -1) {
                     int prev = mc.player.getInventory().selectedSlot;
-                    mc.player.getInventory().selectedSlot = slot;
-                    Managers.NETWORK.sendPacket(new UpdateSelectedSlotC2SPacket(slot));
+                    Managers.INVENTORY.setClientSlot(slot);
                     mc.interactionManager.interactItem(mc.player, Hand.MAIN_HAND);
-                    mc.player.getInventory().selectedSlot = prev;
-                    Managers.NETWORK.sendPacket(new UpdateSelectedSlotC2SPacket(prev));
+                    Managers.INVENTORY.setClientSlot(prev);
                 }
             }
         }

--- a/src/main/java/net/shoreline/client/impl/module/movement/ElytraFlyModule.java
+++ b/src/main/java/net/shoreline/client/impl/module/movement/ElytraFlyModule.java
@@ -5,7 +5,6 @@ import net.minecraft.entity.projectile.FireworkRocketEntity;
 import net.minecraft.item.FireworkRocketItem;
 import net.minecraft.item.ItemStack;
 import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket;
-import net.minecraft.network.packet.c2s.play.UpdateSelectedSlotC2SPacket;
 import net.minecraft.util.Hand;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.Vec3d;
@@ -144,11 +143,9 @@ public class ElytraFlyModule extends ToggleModule {
         }
         if (slot != -1) {
             int prev = mc.player.getInventory().selectedSlot;
-            mc.player.getInventory().selectedSlot = slot;
-            Managers.NETWORK.sendPacket(new UpdateSelectedSlotC2SPacket(slot));
+            Managers.INVENTORY.setClientSlot(slot);
             mc.interactionManager.interactItem(mc.player, Hand.MAIN_HAND);
-            mc.player.getInventory().selectedSlot = prev;
-            Managers.NETWORK.sendPacket(new UpdateSelectedSlotC2SPacket(prev));
+            Managers.INVENTORY.setClientSlot(prev);
         }
     }
 

--- a/src/main/java/net/shoreline/client/impl/module/movement/NoSlowModule.java
+++ b/src/main/java/net/shoreline/client/impl/module/movement/NoSlowModule.java
@@ -104,10 +104,8 @@ public class NoSlowModule extends ToggleModule {
             ItemStack offHandStack = mc.player.getOffHandStack();
             //
             if (mc.player.getActiveHand() == Hand.OFF_HAND) {
-                Managers.NETWORK.sendPacket(new UpdateSelectedSlotC2SPacket(
-                        mc.player.getInventory().selectedSlot % 8 + 1));
-                Managers.NETWORK.sendPacket(new UpdateSelectedSlotC2SPacket(
-                        mc.player.getInventory().selectedSlot));
+                Managers.INVENTORY.setSlotForced(mc.player.getInventory().selectedSlot % 8 + 1);
+                Managers.INVENTORY.syncToClient();
             } else if (!offHandStack.isFood() && offHandStack.getItem() != Items.BOW && offHandStack.getItem() != Items.CROSSBOW && offHandStack.getItem() != Items.SHIELD) {
                 Managers.NETWORK.sendSequencedPacket(id -> new PlayerInteractItemC2SPacket(Hand.OFF_HAND, id));
             }
@@ -221,7 +219,7 @@ public class NoSlowModule extends ToggleModule {
                 && strictConfig.getValue() && checkSlowed()) {
             // Managers.NETWORK.sendPacket(new UpdateSelectedSlotC2SPacket(0));
             // Managers.NETWORK.sendSequencedPacket(id -> new PlayerInteractItemC2SPacket(Hand.OFF_HAND, id));
-            Managers.NETWORK.sendPacket(new UpdateSelectedSlotC2SPacket(mc.player.getInventory().selectedSlot));
+            Managers.INVENTORY.setSlotForced(mc.player.getInventory().selectedSlot);
         } else if (event.getPacket() instanceof ClickSlotC2SPacket && strictConfig.getValue()) {
             if (mc.player.isUsingItem()) {
                 mc.player.stopUsingItem();


### PR DESCRIPTION
Sending a `UpdateSelectedSlotC2SPacket` without checking can cause BackPacketsA to flag on Grim, so updating the InventoryManager is beneficial to prevent future flags. I have already updated the rest of the client to use the inventory manager.

The new methods follow:

`setSlot(int)` - Spoofs only the server slot (not client-sided) while checking if the slot if valid*
`setClientSlot(int)` - Sets the client-sided slot and then syncs to the server if the slot is valid*
`setSlotForced(int)` - Sets the server slot only and directly sends a `UpdateSelectedSlotC2SPacket` with no slot checks
`syncToClient()` - Syncs the client slot to the server

* Valid checks if the server slot does NOT equal the slot provided & the slot id is 0-8 (due to 9 hotbar slots)

It worked fine for me in testing, but I would recommend making sure nothing is bugging out to my code.